### PR TITLE
Fixing an issue where Rx.Node was pulled out of latest Rx.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/kevinswiber/revolt-json-parser",
   "dependencies": {
-    "rx": "^2.3.18"
+    "rx": "^2.3.18",
+    "rx-node": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "revolt-json-parser",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Parses response bodies to JSON.",
   "main": "parser.js",
   "scripts": {

--- a/parser.js
+++ b/parser.js
@@ -1,5 +1,6 @@
 var Stream = require('stream');
 var Rx = require('rx');
+Rx.Node = require('rx-node');
 
 module.exports = function(handle) {
   handle('response', function(pipeline) {


### PR DESCRIPTION
Adding Rx.Node variable back where it belongs by including the new `rx-node` module published by the reactive extensions team. 
